### PR TITLE
Small fixes

### DIFF
--- a/Scripts/OverlayControllers/PowerUpPicker.cs
+++ b/Scripts/OverlayControllers/PowerUpPicker.cs
@@ -113,7 +113,7 @@ public partial class PowerUpPicker : Control
       powerUpButton.TextureHover = btnTextureHover;
 
       // This ensures that the menu gives feedback to the player when using a controller
-      if (Input.GetConnectedJoypads().Count == 1)
+      if (Input.GetConnectedJoypads().Count > 0)
       {
         powerUpButton.TextureFocused = btnTextureHover;
       }

--- a/Scripts/OverlayControllers/PowerUpPicker.cs
+++ b/Scripts/OverlayControllers/PowerUpPicker.cs
@@ -111,19 +111,26 @@ public partial class PowerUpPicker : Control
       powerUpButton.SetLabel(rarityText + powerUp.Name);
       powerUpButton.TextureNormal = btnTexture;
       powerUpButton.TextureHover = btnTextureHover;
-
-      // This ensures that the menu gives feedback to the player when using a controller
-      if (Input.GetConnectedJoypads().Count > 0)
-      {
-        powerUpButton.TextureFocused = btnTextureHover;
-      }
-
       powerUpButton.TextureDisabled = btnTextureDisabled;
       powerUpButton.Pressed += () => PowerUpPickedListeners?.Invoke(powerUp);
 
       // Disable at first
       powerUpButton.Disabled = true;
-      AddChild(TimerFactory.OneShotSelfDestructingStartedTimer(2, () => powerUpButton.Disabled = false));
+      AddChild(
+        TimerFactory.OneShotSelfDestructingStartedTimer(
+          2,
+          () =>
+          {
+            // This ensures that the menu gives feedback to the player when using a controller
+            if (Input.GetConnectedJoypads().Count > 0)
+            {
+              powerUpButton.TextureFocused = btnTextureHover;
+            }
+
+            powerUpButton.Disabled = false;
+          }
+        )
+      );
 
       powerUpButton.GrabFocus();
     }

--- a/Scripts/OverlayControllers/PowerUpPicker.cs
+++ b/Scripts/OverlayControllers/PowerUpPicker.cs
@@ -111,6 +111,13 @@ public partial class PowerUpPicker : Control
       powerUpButton.SetLabel(rarityText + powerUp.Name);
       powerUpButton.TextureNormal = btnTexture;
       powerUpButton.TextureHover = btnTextureHover;
+
+      // This ensures that the menu gives feedback to the player when using a controller
+      if (Input.GetConnectedJoypads().Count == 1)
+      {
+        powerUpButton.TextureFocused = btnTextureHover;
+      }
+
       powerUpButton.TextureDisabled = btnTextureDisabled;
       powerUpButton.Pressed += () => PowerUpPickedListeners?.Invoke(powerUp);
 

--- a/Scripts/OverlayControllers/PowerUpTextureButton.cs
+++ b/Scripts/OverlayControllers/PowerUpTextureButton.cs
@@ -11,7 +11,6 @@ public partial class PowerUpTextureButton : TextureButton
   public override void _Ready()
   {
     this.AutoWire();
-    GrabFocus();
     ApplyShader();
   }
 

--- a/Scripts/PlayerMovementDelegate.cs
+++ b/Scripts/PlayerMovementDelegate.cs
@@ -106,12 +106,19 @@ public partial class PlayerMovementDelegate : Node
       moveEvent.Velocity.Y
     );
 
-    // Jumping
     var onFloor = CharacterBody.IsOnFloor();
+    var onCeiling = CharacterBody.IsOnCeiling();
+
+    // Hitting the floor or the ceiling should stop the player's vertical movement
+    if (onFloor || onCeiling)
+    {
+      moveEvent.Velocity = new Vector2(moveEvent.Velocity.X, 0);
+    }
+
+    // Hitting the floor should reset nr. of jumps
     if (onFloor)
     {
       _jumpCount = 0;
-      moveEvent.Velocity = new Vector2(moveEvent.Velocity.X, 0);
 
       if (!_onFloorLastCall)
       {
@@ -119,7 +126,6 @@ public partial class PlayerMovementDelegate : Node
         EmitSignal(SignalName.PlayerLand, moveEvent);
       }
     }
-
     _onFloorLastCall = onFloor;
 
     // Gravity

--- a/Scripts/PlayerMovementDelegate.cs
+++ b/Scripts/PlayerMovementDelegate.cs
@@ -110,22 +110,16 @@ public partial class PlayerMovementDelegate : Node
     var onCeiling = CharacterBody.IsOnCeiling();
 
     // Hitting the floor or the ceiling should stop the player's vertical movement
-    if (onFloor || onCeiling)
-    {
-      moveEvent.Velocity = new Vector2(moveEvent.Velocity.X, 0);
-    }
+    moveEvent.Velocity = (onFloor || onCeiling) ? new Vector2(moveEvent.Velocity.X, 0) : moveEvent.Velocity;
 
-    // Hitting the floor should reset nr. of jumps
-    if (onFloor)
+    // Hitting the floor should reset the number of jumps
+    if (onFloor && !_onFloorLastCall)
     {
       _jumpCount = 0;
-
-      if (!_onFloorLastCall)
-      {
-        PlayerEffectsDelegate.AnimationPlayLand();
-        EmitSignal(SignalName.PlayerLand, moveEvent);
-      }
+      PlayerEffectsDelegate.AnimationPlayLand();
+      EmitSignal(SignalName.PlayerLand, moveEvent);
     }
+
     _onFloorLastCall = onFloor;
 
     // Gravity

--- a/Scripts/PowerUpManager.cs
+++ b/Scripts/PowerUpManager.cs
@@ -39,7 +39,7 @@ public static class PowerUpManager
       new PowerUps.BrownianMotionCurse(),
       new PowerUps.FluorescentBurst(),
       new PowerUps.SimpleTrigonometry(),
-      new PowerUps.LuminogravitonFluxCurse(),
+      // new PowerUps.LuminogravitonFluxCurse(),
       new PowerUps.PhotonReversifierCurse(),
       new PowerUps.PheedingPhrenzy(),
       new PowerUps.Randomizer5000(),

--- a/Scripts/PowerUps.cs
+++ b/Scripts/PowerUps.cs
@@ -518,7 +518,7 @@ public static class PowerUps
       private void IncreasePhotonSize(Player player, int damage, PlayerHurtEvent playerHurtEvent)
       {
         _photonDamage++;
-        _photonSize += 0.5f;
+        _photonSize += 0.25f;
       }
     }
   }

--- a/Scripts/PowerUps.cs
+++ b/Scripts/PowerUps.cs
@@ -460,6 +460,7 @@ public static class PowerUps
 
     public void Apply(Player playerWhoSelected, Player otherPlayer)
     {
+      otherPlayer.Rotate((float)Math.PI);
       otherPlayer.PlayerMovementDelegate.PlayerMove += ReverseGravity;
     }
 

--- a/probabilities.csv
+++ b/probabilities.csv
@@ -1,10 +1,9 @@
 Power Up, Probability
-Legendary - 1 000 000 lumen, 0.83%
-Legendary - Photon Sniper, 0.83%
-Legendary - Sticky Thicky Curse, 0.83%
-Legendary - Luminograviton Flux Curse, 0.83%
-Legendary - Pheeding Phrenzy, 0.83%
-Legendary - Photon Phlyer, 0.83%
+Legendary - 1 000 000 lumen, 1.00%
+Legendary - Photon Sniper, 1.00%
+Legendary - Sticky Thicky Curse, 1.00%
+Legendary - Pheeding Phrenzy, 1.00%
+Legendary - Photon Phlyer, 1.00%
 Epic - Post Leg Day Curse, 5.00%
 Epic - Chronostasis, 5.00%
 Epic - Photon Reversifier Curse, 5.00%

--- a/probabilities.csv
+++ b/probabilities.csv
@@ -1,33 +1,34 @@
 Power Up, Probability
-(Legendary) - 1 000 000 lumen, 0.48%
-(Legendary) - Photon Sniper, 0.48%
-(Legendary) - Sticky Thicky Curse, 0.48%
-(Legendary) - Luminograviton Flux Curse, 0.48%
-(Legendary) - Pheeding Phrenzy, 0.48%
-(Legendary) - Photon Phlyer, 0.48%
-(Epic) - Post Leg Day Curse, 1.44%
-(Epic) - Chronostasis, 1.44%
-(Epic) - Photon Reversifier Curse, 1.44%
-(Rare) - Photon Multiplier, 2.88%
-(Rare) - Mega Photon Muncher, 2.88%
-(Rare) - Generator Engine, 2.88%
-(Rare) - Steel Boots Curse, 2.88%
-(Rare) - Bullet Rain, 2.88%
-(Rare) - Momentum Master, 2.88%
-(Rare) - Oingo Boingo Curse, 2.88%
-(Rare) - Brownian Motion Curse, 2.88%
-(Rare) - Simple Trigonometry, 2.88%
-(Rare) - Fake Jordans, 2.88%
-(Rare) - Sketchy Pills, 2.88%
-(Rare) - Sketchy Pills, 2.88%
-(Common) - Photon Boost, 5.29%
-(Common) - Health Boost, 5.29%
-(Common) - Bunny Boost, 5.29%
-(Common) - Photon Enlarger, 5.29%
-(Common) - Photon Accelerator, 5.29%
-(Common) - Gravitronizer, 5.29%
-(Common) - Air Walker, 5.29%
-(Common) - Wall Spider, 5.29%
-(Common) - Fluorescent Burst, 5.29%
-(Common) - Randomizer 5000, 5.29%
-(Common) - Nike Air Jordans, 5.29%
+(Legendary) - 1 000 000 lumen, 0.47%
+(Legendary) - Photon Sniper, 0.47%
+(Legendary) - Sticky Thicky Curse, 0.47%
+(Legendary) - Luminograviton Flux Curse, 0.47%
+(Legendary) - Pheeding Phrenzy, 0.47%
+(Legendary) - Photon Phlyer, 0.47%
+(Epic) - Post Leg Day Curse, 1.42%
+(Epic) - Chronostasis, 1.42%
+(Epic) - Photon Reversifier Curse, 1.42%
+(Epic) - Berserker Juice, 1.42%
+(Rare) - Photon Multiplier, 2.84%
+(Rare) - Mega Photon Muncher, 2.84%
+(Rare) - Generator Engine, 2.84%
+(Rare) - Steel Boots Curse, 2.84%
+(Rare) - Bullet Rain, 2.84%
+(Rare) - Momentum Master, 2.84%
+(Rare) - Oingo Boingo Curse, 2.84%
+(Rare) - Brownian Motion Curse, 2.84%
+(Rare) - Simple Trigonometry, 2.84%
+(Rare) - Fake Jordans, 2.84%
+(Rare) - Sketchy Pills, 2.84%
+(Rare) - Sketchy Pills, 2.84%
+(Common) - Photon Boost, 5.21%
+(Common) - Health Boost, 5.21%
+(Common) - Bunny Boost, 5.21%
+(Common) - Photon Enlarger, 5.21%
+(Common) - Photon Accelerator, 5.21%
+(Common) - Gravitronizer, 5.21%
+(Common) - Air Walker, 5.21%
+(Common) - Wall Spider, 5.21%
+(Common) - Fluorescent Burst, 5.21%
+(Common) - Randomizer 5000, 5.21%
+(Common) - Nike Air Jordans, 5.21%

--- a/probabilities.csv
+++ b/probabilities.csv
@@ -1,34 +1,33 @@
 Power Up, Probability
-(Legendary) - 1 000 000 lumen, 0.47%
-(Legendary) - Photon Sniper, 0.47%
-(Legendary) - Sticky Thicky Curse, 0.47%
-(Legendary) - Luminograviton Flux Curse, 0.47%
-(Legendary) - Pheeding Phrenzy, 0.47%
-(Legendary) - Photon Phlyer, 0.47%
-(Epic) - Post Leg Day Curse, 1.42%
-(Epic) - Chronostasis, 1.42%
-(Epic) - Photon Reversifier Curse, 1.42%
-(Epic) - Berserker Juice, 1.42%
-(Rare) - Photon Multiplier, 2.84%
-(Rare) - Mega Photon Muncher, 2.84%
-(Rare) - Generator Engine, 2.84%
-(Rare) - Steel Boots Curse, 2.84%
-(Rare) - Bullet Rain, 2.84%
-(Rare) - Momentum Master, 2.84%
-(Rare) - Oingo Boingo Curse, 2.84%
-(Rare) - Brownian Motion Curse, 2.84%
-(Rare) - Simple Trigonometry, 2.84%
-(Rare) - Fake Jordans, 2.84%
-(Rare) - Sketchy Pills, 2.84%
-(Rare) - Sketchy Pills, 2.84%
-(Common) - Photon Boost, 5.21%
-(Common) - Health Boost, 5.21%
-(Common) - Bunny Boost, 5.21%
-(Common) - Photon Enlarger, 5.21%
-(Common) - Photon Accelerator, 5.21%
-(Common) - Gravitronizer, 5.21%
-(Common) - Air Walker, 5.21%
-(Common) - Wall Spider, 5.21%
-(Common) - Fluorescent Burst, 5.21%
-(Common) - Randomizer 5000, 5.21%
-(Common) - Nike Air Jordans, 5.21%
+(Legendary) - 1 000 000 lumen, 0.48%
+(Legendary) - Photon Sniper, 0.48%
+(Legendary) - Sticky Thicky Curse, 0.48%
+(Legendary) - Pheeding Phrenzy, 0.48%
+(Legendary) - Photon Phlyer, 0.48%
+(Epic) - Post Leg Day Curse, 1.43%
+(Epic) - Chronostasis, 1.43%
+(Epic) - Photon Reversifier Curse, 1.43%
+(Epic) - Berserker Juice, 1.43%
+(Rare) - Photon Multiplier, 2.86%
+(Rare) - Mega Photon Muncher, 2.86%
+(Rare) - Generator Engine, 2.86%
+(Rare) - Steel Boots Curse, 2.86%
+(Rare) - Bullet Rain, 2.86%
+(Rare) - Momentum Master, 2.86%
+(Rare) - Oingo Boingo Curse, 2.86%
+(Rare) - Brownian Motion Curse, 2.86%
+(Rare) - Simple Trigonometry, 2.86%
+(Rare) - Fake Jordans, 2.86%
+(Rare) - Sketchy Pills, 2.86%
+(Rare) - Sketchy Pills, 2.86%
+(Common) - Photon Boost, 5.24%
+(Common) - Health Boost, 5.24%
+(Common) - Bunny Boost, 5.24%
+(Common) - Photon Enlarger, 5.24%
+(Common) - Photon Accelerator, 5.24%
+(Common) - Gravitronizer, 5.24%
+(Common) - Air Walker, 5.24%
+(Common) - Wall Spider, 5.24%
+(Common) - Fluorescent Burst, 5.24%
+(Common) - Randomizer 5000, 5.24%
+(Common) - Nike Air Jordans, 5.24%


### PR DESCRIPTION
- Nerfed Pheeding Phrenzy
  - Now increases photon size by 25% instead of 50%
- Fixed PowerUp button response when using controller
  - If there is a controller connected, we set the focus texture to be the same as hover texture
- Fixed jumping into ceilings
  - Now, if the player jumps and hits a ceiling, their vertical movement is reset
- Disabled Luminograviton Flux curse
  - Did not work correctly at all :cry: 